### PR TITLE
Add OTel project

### DIFF
--- a/KerpackieDiscordAuth.slnx
+++ b/KerpackieDiscordAuth.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/docs/" />
   <Folder Name="/src/">
     <Project Path="src/Kerpackie.Discord.Auth.Identity/Kerpackie.Discord.Auth.Identity.csproj" />
+    <Project Path="src/Kerpackie.Discord.Auth.OpenTelemetry/Kerpackie.Discord.Auth.OpenTelemetry.csproj" />
     <Project Path="src/Kerpackie.Discord.Auth/Kerpackie.Discord.Auth.csproj" />
   </Folder>
   <Folder Name="/Tests/">

--- a/src/Kerpackie.Discord.Auth.OpenTelemetry/DiscordAuthInstrumentationExtensions.cs
+++ b/src/Kerpackie.Discord.Auth.OpenTelemetry/DiscordAuthInstrumentationExtensions.cs
@@ -1,0 +1,21 @@
+using OpenTelemetry.Trace;
+using Kerpackie.Discord.Auth.Diagnostics;
+
+namespace Kerpackie.Discord.Auth.OpenTelemetry;
+
+/// <summary>
+/// Extension methods for setting up Discord Auth OpenTelemetry instrumentation.
+/// </summary>
+public static class DiscordAuthInstrumentationExtensions
+{
+    /// <summary>
+    /// Adds the Discord Auth instrumentation to the TracerProviderBuilder.
+    /// </summary>
+    /// <param name="builder">The TracerProviderBuilder to add the instrumentation to.</param>
+    /// <returns>The TracerProviderBuilder for chaining.</returns>
+    public static TracerProviderBuilder AddDiscordAuthInstrumentation(this TracerProviderBuilder builder)
+    {
+        builder.AddSource(DiscordAuthDiagnostics.ActivitySourceName);
+        return builder;
+    }
+}

--- a/src/Kerpackie.Discord.Auth.OpenTelemetry/Kerpackie.Discord.Auth.OpenTelemetry.csproj
+++ b/src/Kerpackie.Discord.Auth.OpenTelemetry/Kerpackie.Discord.Auth.OpenTelemetry.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kerpackie.Discord.Auth\Kerpackie.Discord.Auth.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.14.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Kerpackie.Discord.Auth/Diagnostics/DiscordAuthDiagnostics.cs
+++ b/src/Kerpackie.Discord.Auth/Diagnostics/DiscordAuthDiagnostics.cs
@@ -41,6 +41,68 @@ public static class DiscordAuthDiagnostics
     public const string ActivityHandlerOnDiscordLogin = "Handler.OnDiscordLogin";
 
     /// <summary>
+    /// Activity name used when retrieving the user's guilds.
+    /// </summary>
+    public const string ActivityGetGuilds = "GetGuilds";
+
+    /// <summary>
+    /// Activity name used when initiating the login flow.
+    /// </summary>
+    public const string ActivityInitiateLogin = "InitiateLogin";
+
+    // Tag names
+    /// <summary>
+    /// Tag key for the Discord API endpoint being called.
+    /// </summary>
+    public const string TagDiscordEndpoint = "discord.endpoint";
+
+    /// <summary>
+    /// Tag key for the HTTP status code returned by Discord.
+    /// </summary>
+    public const string TagDiscordStatusCode = "discord.status_code";
+
+    /// <summary>
+    /// Tag key for the number of guilds retrieved.
+    /// </summary>
+    public const string TagDiscordGuildCount = "discord.guild_count";
+
+    /// <summary>
+    /// Tag key for the Discord user ID.
+    /// </summary>
+    public const string TagDiscordUserId = "discord.user_id";
+
+    /// <summary>
+    /// Tag key indicating if the Discord user is verified.
+    /// </summary>
+    public const string TagDiscordVerified = "discord.verified";
+
+    /// <summary>
+    /// Tag key for the Discord user's locale.
+    /// </summary>
+    public const string TagDiscordLocale = "discord.locale";
+
+    /// <summary>
+    /// Tag key for the return URL after login.
+    /// </summary>
+    public const string TagDiscordReturnUrl = "discord.return_url";
+
+    // Event names
+    /// <summary>
+    /// Event name for a cache hit.
+    /// </summary>
+    public const string EventCacheHit = "CacheHit";
+
+    /// <summary>
+    /// Event name for a cache miss.
+    /// </summary>
+    public const string EventCacheMiss = "CacheMiss";
+
+    /// <summary>
+    /// Event name when rate limited.
+    /// </summary>
+    public const string EventRateLimited = "RateLimited";
+
+    /// <summary>
     /// The shared <see cref="ActivitySource"/> instance created with <see cref="ActivitySourceName"/>.
     /// </summary>
     /// <remarks>

--- a/src/Kerpackie.Discord.Auth/Endpoints/DiscordCallbackEndpoint.cs
+++ b/src/Kerpackie.Discord.Auth/Endpoints/DiscordCallbackEndpoint.cs
@@ -94,6 +94,10 @@ public static class DiscordCallbackEndpoint
                     OriginalClaims = p.Claims
                 };
 
+                Activity.Current?.SetTag(DiscordAuthDiagnostics.TagDiscordUserId, info.DiscordId);
+                Activity.Current?.SetTag(DiscordAuthDiagnostics.TagDiscordVerified, info.Verified);
+                Activity.Current?.SetTag(DiscordAuthDiagnostics.TagDiscordLocale, info.Locale);
+
                 // Start a nested diagnostic activity around the application handler invocation.
                 using (DiscordAuthDiagnostics.ActivitySource.StartActivity(DiscordAuthDiagnostics.ActivityHandlerOnDiscordLogin))
                 {

--- a/src/Kerpackie.Discord.Auth/Endpoints/DiscordLoginEndpoint.cs
+++ b/src/Kerpackie.Discord.Auth/Endpoints/DiscordLoginEndpoint.cs
@@ -1,4 +1,4 @@
-// filepath: /Users/kerpackie/RiderProjects/KerpackieDiscordAuth/src/Kerpackie.Discord.Auth/Endpoints/DiscordLoginEndpoint.cs
+using Kerpackie.Discord.Auth.Diagnostics;
 using Kerpackie.Discord.Auth.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -43,12 +43,16 @@ public static class DiscordLoginEndpoint
     {
         app.MapGet(settings.LoginPath, (string? returnUrl) =>
         {
+            using var activity = DiscordAuthDiagnostics.ActivitySource.StartActivity(DiscordAuthDiagnostics.ActivityInitiateLogin);
+            
             // Log the incoming login attempt and the optional returnUrl query parameter.
             logger.LogInformation("Initiating Discord Login. ReturnUrl: {ReturnUrl}", returnUrl);
 
             // Determine where to send the user after a successful login:
             // prefer the provided returnUrl query parameter; otherwise use the configured default.
             var targetUrl = !string.IsNullOrEmpty(returnUrl) ? returnUrl : settings.DefaultReturnUrl;
+            
+            activity?.SetTag(DiscordAuthDiagnostics.TagDiscordReturnUrl, targetUrl);
 
             // Build authentication properties:
             // - RedirectUri is where the external provider (Discord) should send the user back to.


### PR DESCRIPTION
This pull request introduces OpenTelemetry instrumentation for Discord authentication, enabling improved observability and diagnostics of authentication flows and interactions with the Discord API. The changes add a new instrumentation project, extend diagnostics with structured activity names, tags, and events, and update existing endpoints and services to emit relevant telemetry data.

**OpenTelemetry Integration:**

* Added new project `Kerpackie.Discord.Auth.OpenTelemetry` with an extension method `AddDiscordAuthInstrumentation` for registering Discord Auth tracing sources in `TracerProviderBuilder`. [[1]](diffhunk://#diff-2d2b94a1dd11f287dcc02bd926b811581cb995e8335ef3e08a98c5c2b304fdabR1-R17) [[2]](diffhunk://#diff-f9df5d7d1333c666013c9e2172b76cbde160d86147621d2f617d4e5687288bdcR1-R21)
* Updated solution file `KerpackieDiscordAuth.slnx` to include the new OpenTelemetry instrumentation project.

**Diagnostics Enhancements:**

* Extended `DiscordAuthDiagnostics` with new activity names (`ActivityGetGuilds`, `ActivityInitiateLogin`), tag keys (e.g., `TagDiscordEndpoint`, `TagDiscordStatusCode`, `TagDiscordGuildCount`, `TagDiscordUserId`, `TagDiscordVerified`, `TagDiscordLocale`, `TagDiscordReturnUrl`), and event names (`EventCacheHit`, `EventCacheMiss`, `EventRateLimited`) for richer telemetry.

**Endpoint and Service Instrumentation:**

* Updated `DiscordLoginEndpoint` and `DiscordCallbackEndpoint` to start activities and set relevant tags (e.g., user ID, verified status, locale, return URL) during authentication flows. [[1]](diffhunk://#diff-89a12a7debae45eb50c0c24f2cc85137b308baa19b668d27323264b0dc513f50L1-R1) [[2]](diffhunk://#diff-89a12a7debae45eb50c0c24f2cc85137b308baa19b668d27323264b0dc513f50R46-R56) [[3]](diffhunk://#diff-178a4781629bce899392756475509f462f95c6b7060fa092e0ea85e47be7f125R97-R100)
* Enhanced `DiscordService` to emit activity events for cache hits/misses, set tags for endpoint, status code, and guild count, and use structured event names for rate limiting. [[1]](diffhunk://#diff-56877d0205c984db083532370eee2275693dbeba38266f23c3a5b0b36050cdecR75-R89) [[2]](diffhunk://#diff-56877d0205c984db083532370eee2275693dbeba38266f23c3a5b0b36050cdecR119-R120) [[3]](diffhunk://#diff-56877d0205c984db083532370eee2275693dbeba38266f23c3a5b0b36050cdecL158-R165) [[4]](diffhunk://#diff-56877d0205c984db083532370eee2275693dbeba38266f23c3a5b0b36050cdecR183) [[5]](diffhunk://#diff-56877d0205c984db083532370eee2275693dbeba38266f23c3a5b0b36050cdecL190-R198)