### PR TITLE
nuget CI

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,48 @@
+name: NuGet
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Get Version
+      id: get_version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet build --no-restore --configuration Release /p:Version=${{ env.VERSION }}
+
+    - name: Test
+      run: dotnet test --no-build --configuration Release --verbosity normal
+      
+    - name: Pack Kerpackie.Discord.Auth
+      run: dotnet pack src/Kerpackie.Discord.Auth/Kerpackie.Discord.Auth.csproj --no-build --configuration Release --output nupkgs /p:Version=${{ env.VERSION }}
+      
+    - name: Pack Kerpackie.Discord.Auth.Identity
+      run: dotnet pack src/Kerpackie.Discord.Auth.Identity/Kerpackie.Discord.Auth.Identity.csproj --no-build --configuration Release --output nupkgs /p:Version=${{ env.VERSION }}
+
+    - name: Pack Kerpackie.Discord.Auth.OpenTelemetry
+      run: dotnet pack src/Kerpackie.Discord.Auth.OpenTelemetry/Kerpackie.Discord.Auth.OpenTelemetry.csproj --no-build --configuration Release --output nupkgs /p:Version=${{ env.VERSION }}
+      
+    - name: Upload NuGet Packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-packages
+        path: nupkgs/*.nupkg
+
+    - name: Publish to NuGet
+      run: dotnet nuget push nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 docs/AspireDemo/AspireDemo.ApiService/appsettings.json
+
+docs/AspireDemo.Basic/AspireDemo.Basic.ApiService/appsettings.json


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building, testing, packaging, and publishing NuGet packages when a new version tag is pushed. The workflow automates the release process for multiple projects within the repository.

**Continuous Integration and Deployment:**

* Added a `.github/workflows/nuget.yml` workflow that triggers on version tag pushes matching the pattern `v*`, automating the build and release pipeline for NuGet packages.

**Build and Packaging Automation:**

* Configured steps to restore dependencies, build the solution, run tests, and pack three projects: `Kerpackie.Discord.Auth`, `Kerpackie.Discord.Auth.Identity`, and `Kerpackie.Discord.Auth.OpenTelemetry`, with the version derived from the tag.

**Artifact Management and Publishing:**

* Added steps to upload the generated NuGet packages as workflow artifacts and publish them to NuGet.org using a secret API key.