### PR TITLE
Updated Docs and Licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Kerpackie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,133 @@
+# Kerpackie.Discord.Auth
+
+[![NuGet](https://img.shields.io/nuget/v/Kerpackie.Discord.Auth.svg)](https://www.nuget.org/packages/Kerpackie.Discord.Auth)
+[![Build Status](https://github.com/kerpackie/KerpackieDiscordAuth/actions/workflows/dotnet.yml/badge.svg)](https://github.com/kerpackie/KerpackieDiscordAuth/actions)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+**Kerpackie.Discord.Auth** is a robust, developer-friendly library for integrating Discord OAuth2 authentication into your ASP.NET Core applications. Whether you need simple "Login with Discord" functionality or deep integration with ASP.NET Core Identity, this library has you covered.
+
+## ✨ Features
+
+- **🚀 Seamless Integration**: Get up and running with just a few lines of code.
+- **🔐 Identity Support**: Full compatibility with ASP.NET Core Identity for user persistence and management.
+- **📊 OpenTelemetry**: Built-in instrumentation for tracing authentication flows and diagnosing issues.
+- **🛠️ Flexible Configuration**: Customize redirect paths, scopes, and claim mapping to fit your needs.
+- **📦 Modular Design**: Use only what you need—core auth, identity integration, or observability.
+
+## 📦 Installation
+
+Install the packages via NuGet:
+
+```bash
+# Core Library
+dotnet add package Kerpackie.Discord.Auth
+
+# Identity Integration (Optional)
+dotnet add package Kerpackie.Discord.Auth.Identity
+
+# OpenTelemetry Instrumentation (Optional)
+dotnet add package Kerpackie.Discord.Auth.OpenTelemetry
+```
+
+## 🚀 Quick Start
+
+### Scenario A: Basic Login (No Database)
+
+Ideal for simple apps or tools where you just need to verify a Discord user.
+
+```csharp
+// Program.cs
+using Kerpackie.Discord.Auth.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// 1. Register Discord Auth
+builder.Services.AddDiscordAuth<MyAuthHandler>(builder.Configuration);
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+// 2. Map Endpoints (/auth/discord/login, /auth/discord/callback)
+app.MapDiscordAuth();
+
+app.Run();
+```
+
+**Implement the Handler:**
+
+```csharp
+public class MyAuthHandler : IDiscordAuthHandler
+{
+    public Task<ClaimsPrincipal> OnDiscordLoginAsync(DiscordLoginContext context)
+    {
+        var identity = new ClaimsIdentity("Cookies");
+        identity.AddClaim(new Claim(ClaimTypes.Name, context.Username));
+        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, context.DiscordId));
+        return Task.FromResult(new ClaimsPrincipal(identity));
+    }
+}
+```
+
+### Scenario B: ASP.NET Core Identity
+
+Perfect for full-stack applications requiring user accounts and database persistence.
+
+```csharp
+// Program.cs
+using Kerpackie.Discord.Auth.Identity;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// 1. Setup Identity
+builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
+    .AddEntityFrameworkStores<ApplicationDbContext>();
+
+// 2. Add Discord Auth with Identity
+builder.Services.AddDiscordAuthWithIdentity<ApplicationUser>(builder.Configuration);
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapDiscordAuth();
+
+app.Run();
+```
+
+## ⚙️ Configuration
+
+Add your Discord credentials to `appsettings.json`:
+
+```json
+{
+  "Kerpackie.Discord.Auth": {
+    "ClientId": "YOUR_CLIENT_ID",
+    "ClientSecret": "YOUR_CLIENT_SECRET",
+    "LoginPath": "/auth/discord/login",
+    "CallbackPath": "/auth/discord/callback"
+  }
+}
+```
+
+## 📊 Observability
+
+Enable OpenTelemetry tracing to monitor your authentication flows:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => 
+    {
+        tracing.AddDiscordAuthInstrumentation();
+    });
+```
+
+## 📚 Documentation
+
+For detailed guides, advanced configuration, and examples, check out the [Documentation](docs/README.md).
+
+## 📄 License
+
+Licensed under the [MIT License](LICENSE).

--- a/src/Kerpackie.Discord.Auth.Identity/Kerpackie.Discord.Auth.Identity.csproj
+++ b/src/Kerpackie.Discord.Auth.Identity/Kerpackie.Discord.Auth.Identity.csproj
@@ -5,7 +5,14 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+        <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />

--- a/src/Kerpackie.Discord.Auth.OpenTelemetry/Kerpackie.Discord.Auth.OpenTelemetry.csproj
+++ b/src/Kerpackie.Discord.Auth.OpenTelemetry/Kerpackie.Discord.Auth.OpenTelemetry.csproj
@@ -12,6 +12,13 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
+
+  <ItemGroup>
+      <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+      <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
 </Project>

--- a/src/Kerpackie.Discord.Auth/Kerpackie.Discord.Auth.csproj
+++ b/src/Kerpackie.Discord.Auth/Kerpackie.Discord.Auth.csproj
@@ -5,7 +5,14 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+        <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
This pull request introduces important improvements to project documentation and packaging for the Kerpackie.Discord.Auth library and its related packages. The main changes include adding a comprehensive `README.md` and an MIT `LICENSE` file, and updating project files so that these documents are properly bundled and referenced in NuGet packages.

**Documentation and Licensing:**

* Added a detailed `README.md` with usage instructions, features, installation steps, and configuration examples for Kerpackie.Discord.Auth.
* Added an MIT `LICENSE` file to clarify the project's licensing terms.

**NuGet Packaging Improvements:**

* Updated `Kerpackie.Discord.Auth.csproj`, `Kerpackie.Discord.Auth.Identity.csproj`, and `Kerpackie.Discord.Auth.OpenTelemetry.csproj` to:
  - Reference the `README.md` and `LICENSE` files in NuGet package metadata for improved discoverability. [[1]](diffhunk://#diff-2e50945347d3a9e2fc61fc566af8c408958298ac35f7a4ef39c419a99174ff38R8-R16) [[2]](diffhunk://#diff-7a764289ced663f3c992a4f899e8e9cda990fdc7358c00bb531a87cc21bb33abR8-R16) [[3]](diffhunk://#diff-2d2b94a1dd11f287dcc02bd926b811581cb995e8335ef3e08a98c5c2b304fdabR15-R23)
  - Ensure the `README.md` and `LICENSE` files are included in the root of each published NuGet package. [[1]](diffhunk://#diff-2e50945347d3a9e2fc61fc566af8c408958298ac35f7a4ef39c419a99174ff38R8-R16) [[2]](diffhunk://#diff-7a764289ced663f3c992a4f899e8e9cda990fdc7358c00bb531a87cc21bb33abR8-R16) [[3]](diffhunk://#diff-2d2b94a1dd11f287dcc02bd926b811581cb995e8335ef3e08a98c5c2b304fdabR15-R23)

These changes make the packages more user-friendly and compliant with open source best practices.